### PR TITLE
Recognize lowercase AG keywords for haskell-like syntax mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
     "name": "uuag-language-syntax",
     "displayName": "uuag",
     "description": "Utretch University Attribute Grammars (uuag) language syntax highlight",
-    "version": "0.0.1",
+    "publisher": "edo-codes",
+    "version": "0.0.2",
     "engines": {
         "vscode": "^1.54.0"
     },

--- a/syntaxes/uuag.tmLanguage.json
+++ b/syntaxes/uuag.tmLanguage.json
@@ -16,7 +16,7 @@
 		"keywords": {
 			"patterns": [{
 				"name": "keyword.control.uuag",
-				"match": "\\b(DATA|ATTR|TYPE|SEM|INCLUDE|DERIVING|imports|SET|PRAGMA)\\b"
+				"match": "\\b(DATA|ATTR|TYPE|SEM|INCLUDE|DERIVING|imports|SET|PRAGMA|data|attr|type|sem|include|deriving|set|pragma)\\b"
 			}]
 		},
 		"strings": {


### PR DESCRIPTION
Uppercase keywords are part of old-style UUAG syntax, now both are recognized